### PR TITLE
update artist test passes

### DIFF
--- a/tracticeapi/tests/artist.py
+++ b/tracticeapi/tests/artist.py
@@ -35,3 +35,16 @@ class ArtistTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response['name'], "Nate Smith")
+
+    def test_update_artist(self):
+        self.test_create_artist()
+        url = '/artists/1'
+        data = {"name": "Jojo Mayer"}
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        put_response = self.client.put(url, data, format='json')
+        self.assertEqual(put_response.status_code, status.HTTP_204_NO_CONTENT)
+
+        get_response = self.client.get(url, format='json')
+        json_response = json.loads(get_response.content)
+        self.assertEqual(json_response['name'], "Jojo Mayer")


### PR DESCRIPTION
I updated the create and update view set for artists, which now is more specific in returning 201 for created and 204 no content when an artist is updated. These endpoints have been tested using python tests, and have passed both tests.